### PR TITLE
替换了失效的图片url

### DIFF
--- a/pages/main/main.vue
+++ b/pages/main/main.vue
@@ -154,7 +154,7 @@ export default {
                     label: '2025蛇年春晚时间地点官宣',
                 },
                 {
-                    imgUrl: 'https://prod-9gip97mx4bfa32a3-1312104819.tcloudbaseapp.com/ads/main%20page%20ads/2025%E6%98%A5%E6%99%9A%E4%B8%BB%E6%8C%81%E4%BA%BA%E6%8B%9B%E5%8B%9F.png?sign=b9aa28b04686b9cb2dc41e85d3c001a9&t=1731120159',
+                    imgUrl: 'https://prod-9gip97mx4bfa32a3-1312104819.tcloudbaseapp.com/ads/main%20page%20ads/2025%E8%9B%87%E5%B9%B4%E5%AF%BC%E6%BC%94%E7%BB%84%E4%BB%8B%E7%BB%8D.png?sign=2bacdcec5814c520ec0dbdf1c684f0d9&t=1737687799',
                     link: 'https://mp.weixin.qq.com/s/r21LNuaNVVmwSr09VOamcA',
                     label: '2025蛇年导演组',
                 },


### PR DESCRIPTION
我刚才跑的时候发现导演组介绍的图片链接失效了。这个是新的。